### PR TITLE
Update image route of API on the mini computer

### DIFF
--- a/mini_computer_api/main.py
+++ b/mini_computer_api/main.py
@@ -1,16 +1,16 @@
 from flask import Flask
 from flask_cors import CORS
-from resources.camera import Camera
-from datetime import datetime
+from resources.camera_controller import CameraController
+from datetime import date
 import logging
 
 
 # setup the logging file and logging configurations
-logfile = f"{datetime.utcnow().strftime('%Y-%m-%d')}_server_log.log"
+logfile = f"{date.today()}_server_log.log"
 logging.basicConfig(filename=logfile, filemode="a", format="[ %(asctime)s ] %(message)s ", datefmt="%m-%d-%y %H:%M:%S", level=logging.INFO)
 
 STATE = 'NC'
-sony_camera = Camera(STATE)
+sony_camera = CameraController(STATE)
 app = Flask(__name__)
 CORS(app)
 

--- a/mini_computer_api/resources/camera_controller.py
+++ b/mini_computer_api/resources/camera_controller.py
@@ -1,6 +1,6 @@
 from flask import make_response, send_file
 from from_root import from_root
-from datetime import datetime
+from datetime import date
 from pathlib import Path
 import os
 import time
@@ -11,17 +11,18 @@ import cv2
 import io
 
 
-class Camera():
+class CameraController():
 
     def __init__(self, state):
         # setup directory to save images
         self.location = state
-        imgDir = f"Loc_{self.location}_{datetime.utcnow().strftime('%Y-%m-%d')}"
-        self.dirName = from_root("mini_computer_api", imgDir)
+        parent_dir = "mini_computer_api"
+        imgDir = f"Loc_{self.location}_{date.today()}"
+        self.dirName = from_root(parent_dir, imgDir)
         Path(self.dirName).mkdir(parents=True, exist_ok=True)
 
         # define the path to executable file of the camera
-        self.camera_exe_path = from_root("mini_computer_api", "resources", "RemoteCli")
+        self.camera_exe_path = from_root(parent_dir, "resources", "RemoteCli")
 
 
     # function for capturing a set of images and if successful, send a preview of the image captured
@@ -80,7 +81,10 @@ class Camera():
     def move_files(self):
         for file_name in os.listdir('.'):
             if file_name.startswith(self.location):
-                shutil.move(file_name, self.dirName)
+                try:
+                    shutil.move(file_name, self.dirName)
+                except:
+                    continue
 
 
     # function to find the latest jpeg file in the image directory


### PR DESCRIPTION
- created a class to handle all operations related to capturing, renaming and moving image files
- class also handles other minor operations like finding latest file, encoding image for preview
- remove retry logic of capturing images after failure, this would be handled in frontend

There are only 2 defined API routes now:
/image
- triggers camera to capture image
- if successful, then a preview of jpeg image just taken is returned in response
- if unsuccessful, then an error message is returned as a response

/image_latest
- finds latest jpeg image and returns it as a response
- if no jpeg file is found in the directory (if there were no previous image captures), then an error response is returned

